### PR TITLE
Fix Container Tests by adding missing container start method

### DIFF
--- a/tests/core/Container.test.ts
+++ b/tests/core/Container.test.ts
@@ -196,7 +196,8 @@ test('static prune()', async (t) => {
       pruneTest: 'true'
     }
   })
-  Container.stop({ id: resp.Id })
+  await Container.start({ id: resp.Id })
+  Container.stop({ id: resp.Id }, { t: 1 })
   await Container.wait({ id: resp.Id })
   const prune = await Container.prune({
     filters: JSON.stringify({ label: ['pruneTest'] })


### PR DESCRIPTION
## Description

In the `static prune()` tests, the call to `wait Container.start({ id: resp.Id })` was missed, which returned a 404 error.