### PR TITLE
Implement Secret API

### DIFF
--- a/src/api/SecretAPI.ts
+++ b/src/api/SecretAPI.ts
@@ -1,0 +1,34 @@
+import { plainToInstance } from 'class-transformer'
+import { Secret } from '../core/Secret.js'
+import { GetParamType } from '../utils/GetParamType.js'
+
+export class SecretAPI {
+  /**
+   * List secrets
+   */
+  static async list(query?: GetParamType<'SecretList'>['query']) {
+    return plainToInstance(Secret, await Secret.list(query))
+  }
+
+  /**
+   * Get secret
+   * @param id Secret ID
+   */
+  static async get(id: string) {
+    const secret = await Secret.list({
+      filters: JSON.stringify({ id: [id] })
+    })
+    return plainToInstance(Secret, secret[0])
+  }
+
+  /**
+   * Create a secret
+   */
+  static async create(body: GetParamType<'SecretCreate'>['body']['body']) {
+    const createdSecret = await Secret.create(body)
+    const secret = await Secret.list({
+      filters: JSON.stringify({ id: [createdSecret.Id] })
+    })
+    return plainToInstance(Secret, secret[0])
+  }
+}

--- a/src/core/Secret.ts
+++ b/src/core/Secret.ts
@@ -76,34 +76,4 @@ export class Secret extends AbstractEndpoint<ISecret> {
   delete() {
     return Secret.delete({ id: this.ID })
   }
-
-  /**
-   * Update a Secret
-   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretUpdate
-   */
-  static update(
-    path: GetParamType<'SecretUpdate'>['path'],
-    query: GetParamType<'SecretUpdate'>['query'],
-    body: GetParamType<'SecretUpdate'>['body']['body']
-  ) {
-    return jsonEndpoint<GetResponseType<'SecretUpdate', 200>>(
-      'post',
-      `secrets/${path.id}/update`,
-      {
-        searchParams: query,
-        json: body
-      }
-    )
-  }
-
-  /**
-   * Update a Secret
-   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretUpdate
-   */
-  update(
-    query: GetParamType<'SecretUpdate'>['query'],
-    body: GetParamType<'SecretUpdate'>['body']['body']
-  ) {
-    return Secret.update({ id: this.ID }, query, body)
-  }
 }

--- a/src/core/Secret.ts
+++ b/src/core/Secret.ts
@@ -1,0 +1,109 @@
+import { jsonEndpoint } from '../DockerAPI.js'
+import { definitions } from '../specs/v1.41.js'
+import { GetParamType } from '../utils/GetParamType.js'
+import { GetResponseType } from '../utils/GetResponseType.js'
+import { AbstractEndpoint } from './AbstractEndpoint.js'
+
+export type ISecret = definitions['Secret']
+type Version = definitions['ObjectVersion']
+type Spec = definitions['SecretSpec']
+
+export class Secret extends AbstractEndpoint<ISecret> {
+  ID!: string
+  Version!: Version
+  CreatedAt!: string
+  UpdatedAt!: string
+  Spec!: Spec
+
+  /**
+   * List secrets
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretList
+   */
+  static list(query?: GetParamType<'SecretList'>['query']) {
+    return jsonEndpoint<GetResponseType<'SecretList', 200>>('get', 'secrets', {
+      searchParams: query
+    })
+  }
+
+  /**
+   * Create a secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretCreate
+   */
+  static create(body: GetParamType<'SecretCreate'>['body']['body']) {
+    return jsonEndpoint<GetResponseType<'SecretCreate', 201>>(
+      'post',
+      'secrets/create',
+      {
+        json: body
+      }
+    )
+  }
+
+  /**
+   * Inspect a secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretInspect
+   */
+  static inspect(path: GetParamType<'SecretInspect'>['path']) {
+    return jsonEndpoint<GetResponseType<'SecretInspect', 200>>(
+      'get',
+      `secrets/${path.id}`
+    )
+  }
+
+  /**
+   * Inspect a secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretInspect
+   */
+  inspect() {
+    return Secret.inspect({ id: this.ID })
+  }
+
+  /**
+   * Delete a secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretDelete
+   */
+  static delete(path: GetParamType<'SecretDelete'>['path']) {
+    return jsonEndpoint<GetResponseType<'SecretDelete', 204>>(
+      'delete',
+      `secrets/${path.id}`
+    )
+  }
+
+  /**
+   * Delete a secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretDelete
+   */
+  delete() {
+    return Secret.delete({ id: this.ID })
+  }
+
+  /**
+   * Update a Secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretUpdate
+   */
+  static update(
+    path: GetParamType<'SecretUpdate'>['path'],
+    query: GetParamType<'SecretUpdate'>['query'],
+    body: GetParamType<'SecretUpdate'>['body']['body']
+  ) {
+    return jsonEndpoint<GetResponseType<'SecretUpdate', 200>>(
+      'post',
+      `secrets/${path.id}/update`,
+      {
+        searchParams: query,
+        json: body
+      }
+    )
+  }
+
+  /**
+   * Update a Secret
+   * @link https://docs.docker.com/engine/api/v1.41/#tag/Secret/operation/SecretUpdate
+   */
+  update(
+    query: GetParamType<'SecretUpdate'>['query'],
+    body: GetParamType<'SecretUpdate'>['body']['body']
+  ) {
+    return Secret.update({ id: this.ID }, query, body)
+  }
+}


### PR DESCRIPTION
## Description

Implement Secret API (see https://docs.docker.com/engine/api/v1.41/#tag/Secret) with full test coverage.

## Note

Based on the Docker API, you CAN update a Secret after its creation.
However, according to the Docker documentation and our tests, it is not possible to update a secret after its creation. (see https://docs.docker.com/engine/swarm/secrets/)

There's also a problem with the SecretCreate operation. By looking at the documentation, it is said that it should return a string named "Id". However, it returns "ID".
